### PR TITLE
Remove dependecy on `node-int64`

### DIFF
--- a/lib/packet.js
+++ b/lib/packet.js
@@ -23,7 +23,6 @@
 
 const { Writable } = require('stream')
 const varint = require('varint')
-const Int64 = require('node-int64')
 
 const PROTOCOL_VERSION = 736 // Minecraft 1.16.1
 
@@ -45,7 +44,9 @@ module.exports.createHandshakePacket = (address, port) => {
 }
 
 module.exports.createPingPacket = (timestamp) => {
-  return createPacket(1, new Int64(timestamp).toBuffer())
+  let timestampBuffer = Buffer.allocUnsafe(8)
+  timestampBuffer.writeBigInt64BE(BigInt(timestamp), 0)
+  return createPacket(1, timestampBuffer)
 }
 
 function createPacket (packetId, data) {
@@ -140,7 +141,7 @@ function decodeHandshakeResponse (packet) {
 function decodePong (packet) {
   return new Promise((resolve, reject) => {
     // Decode timestamp
-    let timestamp = new Int64(packet.data)
+    let timestamp = Number(BigInt(`0x${packet.data.toString('hex')}`))
 
     packet.result = Date.now() - timestamp
     resolve(packet)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "standard": "^7.1.2"
   },
   "dependencies": {
-    "node-int64": "^0.4.0",
     "varint": "^4.0.1"
   }
 }


### PR DESCRIPTION
Since 10.4.0, NodeJS has supported the `BigInt` object natively. Utilizing it allows minecraft-pinger to drop its `node-int64` dependency (which has been depreciated for more than 2 years), reducing the library's external dependencies to just `varint`.